### PR TITLE
Update kotlin version for android gradle plugin 3.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'dev.imamurh.shift_jis'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.10'
     repositories {
         google()
         jcenter()

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
 
+android.enableR8=true


### PR DESCRIPTION
Hi,

I failed to build my project using `shift_jis(0.2.0)` with Android Studio 3.5.3.

```
FAILURE: Build failed with an exception.

* What went wrong:
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.3.10 and higher.
The following dependencies do not satisfy the required version:
project ':shift_jis' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.71

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 5s
Finished with error: Gradle task assembleDebug failed with exit code 1
```

This seems to be due to incompatible kotlin versions, so I make a PR.
I am not sure this is the best solution...